### PR TITLE
Fix example code in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ end
 def insert(mysql, data)
   values = data.to_hash.values_at(*COLUMNS)
   addresseralias = data.addresser.alias
-  addresseralias = data.addresser if addresseralias.empty?
+  addresseralias = data.addresser.to_s if addresseralias.empty?
   values << addresseralias
   columns = (COLUMNS + ['addresseralias', 'digest', 'created_at', 'updated_at']).join(?,)
   timestamp = values.shift


### PR DESCRIPTION
Hello

Does example code miss `to_s` method?

This code returns the following statement.
MySQL server return invalid syntax error.

It contains `#<Sisimai::Address:0x0055f61f98bbb8 @user="admin", @host="example.ad.jp", @address="admin@example.ad.jp", @alias="", @verp="">`

```
INSERT INTO bounce_mails (timestamp,lhost,rhost,alias,listid,reason,action,subject,messageid,smtpagent,softbounce,smtpcommand,destination,senderdomain,feedbacktype,diagnosticcode,deliverystatus,timezoneoffset,addresser,recipient,addresseralias,digest,created_at,updated_at) VALUES (FROM_UNIXTIME(1219921820),"tgmsbbky42sb.softbank.ne.jp","mmta14.softbank.ne.jp","","","mailboxfull","failed","TEST","20080828111019688.TNQR.8636@tgmsbbky42sb.softbank.ne.jp","RFC3464",1,"","d.vodafone.ne.jp","example.ad.jp","","","4.2.2","+0900","admin@example.ad.jp","this-destination-mailbox-is-full@d.vodafone.ne.jp",#<Sisimai::Address:0x0055f61f98bbb8 @user="admin", @host="example.ad.jp", @address="admin@example.ad.jp", @alias="", @verp="">,SHA1(recipient),NOW(),NOW())
```